### PR TITLE
Harden PAM helper and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,22 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+  staticcheck:
+    name: Staticcheck
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
       - name: Run Staticcheck
-        run: go run honnef.co/go/tools/cmd/staticcheck ./...
+        run: make staticcheck
 
   test:
     name: Test
@@ -63,7 +77,7 @@ jobs:
 
   smoke:
     name: Smoke
-    needs: [lint, test]
+    needs: [lint, staticcheck, test]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -103,7 +117,7 @@ jobs:
 
   package-linux:
     name: Package Linux (${{ matrix.goarch }})
-    needs: [lint, test, smoke]
+    needs: [lint, staticcheck, test, smoke]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -159,6 +173,9 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -188,6 +205,11 @@ jobs:
           find artifacts -type f -name '*.tar.gz.sha256' -exec cp {} release/ \;
           cd release
           sha256sum *.tar.gz > SHA256SUMS.txt
+
+      - name: Attest release provenance
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS.txt
 
       - name: Create release
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ The format is intentionally lightweight while the project is pre-production.
 - Parser fuzzing split into 5s CI/pre-push smoke, 60s release validation, and 5m scheduled nightly runs.
 - CI distributable artifacts limited to Linux `amd64` and `arm64` until macOS and Windows signing tracks are ready.
 - Coverage gate added with 85% minimum coverage for internal product logic packages.
+- Operational hardening for bounded checker input, public HIBP HTTPS validation, single-context provider timeouts, and bounded PAM checker stderr diagnostics.
+- Documentation updates for Ubuntu PAM deployment, rollback, helper exit mapping, HIBP request volume, threat model details, versioning, and log examples.
+- Staticcheck split into a standalone CI job ready for required branch protection, with release provenance attestation over published checksums.
+- PAM helper `--max-bytes` option and Prometheus-style counter examples for operational log pipelines.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ echo $?
 
 Input:
 - `--stdin` reads one password from standard input.
+- stdin input is bounded to 4096 bytes.
 
 Exit codes:
 - `0`: clean, or provider failure when fail-open is enabled
@@ -41,6 +42,8 @@ Version:
 ```
 pwned-check --version
 ```
+
+The project does not promise backwards compatibility while the concept is being shaped. The CLI stdin, exit-code, and safe logging contracts are expected to stabilize at `v1.0.0`.
 
 ## Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,26 +6,26 @@ Use this page as the front door for project and operator documentation. The docs
 
 | Need | Start here |
 |---|---|
-| Try the checker locally | [Quickstart](quickstart.md) |
-| Confirm platform and deployment assumptions | [Requirements](requirements.md) |
-| Configure live HIBP provider behavior | [Provider policy](provider-policy.md) |
-| Understand install, upgrade, and rollback shape | [Operations](operations.md) |
-| Test Linux password-change integration | [Linux PAM PoC](linux-pam-poc.md) |
-| Understand secret-handling and privilege boundaries | [Security model](security-model.md) |
-| Review log events and safe diagnostics | [Logging policy](logging-policy.md) |
-| Prepare for secure rollout | [Deployment security checklist](deployment-security-checklist.md) |
-| Diagnose rollout issues | [Operational troubleshooting](troubleshooting.md) |
-| Understand the CLI contract and long-term design | [Development and architecture](development-architecture.md) |
+| Try the checker locally | [Quickstart](quickstart.md): local CLI examples, fail-open/fail-closed checks, and binary smoke |
+| Confirm platform and deployment assumptions | [Requirements](requirements.md): current Linux-first scope and integration constraints |
+| Configure live HIBP provider behavior | [Provider policy](provider-policy.md): live API use, timeout, request volume, and test-provider boundary |
+| Understand install, upgrade, and rollback shape | [Operations](operations.md): package layout, Ubuntu PAM walkthrough, rollback, and helper mapping |
+| Test Linux password-change integration | [Linux PAM PoC](linux-pam-poc.md): PAM helper contract and manual password-change test plan |
+| Understand secret-handling and privilege boundaries | [Security model](security-model.md): provider boundary, process exposure, env, argv, and non-goals |
+| Review log events and safe diagnostics | [Logging policy](logging-policy.md): event catalog, example lines, and safe fields |
+| Prepare for secure rollout | [Deployment security checklist](deployment-security-checklist.md): rollout and recovery controls |
+| Diagnose rollout issues | [Operational troubleshooting](troubleshooting.md): exit codes, helper events, and outage checks |
+| Understand the CLI contract and long-term design | [Development and architecture](development-architecture.md): design principles and stability expectations |
 
 ## Maintainer Path
 
 | Need | Start here |
 |---|---|
-| Understand the roadmap | [Roadmap](roadmap.md) |
-| Track issues and board workflow | [Project board workflow](project-board-workflow.md) |
-| Validate code changes | [Testing](testing.md) |
-| Validate Linux distro runtime and PAM package integration | [Docker smoke matrix](docker-smoke.md) |
-| Prepare a release | [Release playbook](release-playbook.md) |
+| Understand the roadmap | [Roadmap](roadmap.md): epics, user stories, and current implementation notes |
+| Track issues and board workflow | [Project board workflow](project-board-workflow.md): issue fields, workflow statuses, and audit rules |
+| Validate code changes | [Testing](testing.md): local gate, coverage threshold, fuzz schedule, and CI expectations |
+| Validate Linux distro runtime and PAM package integration | [Docker smoke matrix](docker-smoke.md): distro image matrix and PAM package smoke behavior |
+| Prepare a release | [Release playbook](release-playbook.md): release validation, Linux artifacts, and failure rule |
 
 ## Suggested First-Time Flow
 

--- a/docs/development-architecture.md
+++ b/docs/development-architecture.md
@@ -69,6 +69,8 @@ flowchart LR
 
 This contract is intentionally small. Changes to it should be treated as architecture decisions and documented before implementation.
 
+The project may change the contract before `v1.0.0` while the concept is still being shaped. At `v1.0.0`, the stdin input model, exit-code meanings, and safe log event shape should be treated as stable unless a future major version explicitly changes them.
+
 ## Controls
 
 ### Security Controls

--- a/docs/linux-pam-poc.md
+++ b/docs/linux-pam-poc.md
@@ -64,6 +64,8 @@ password requisite pam_exec.so expose_authtok quiet /usr/local/bin/pwned-check-p
 
 Place the line before `pam_unix.so` in `/etc/pam.d/common-password` so rejected passwords fail before the local password is changed.
 
+The helper reads at most 4096 bytes from stdin by default. Operators can tune this with `--max-bytes <n>` if a deployment has a documented need for a different bound; values above 1048576 bytes are rejected.
+
 ## Manual Test Plan
 
 Use a disposable VM. Keep an existing root shell open while testing PAM changes.

--- a/docs/logging-policy.md
+++ b/docs/logging-policy.md
@@ -19,6 +19,13 @@
 
 `prefix` is the first five hex characters of the candidate password SHA-1 hash. It is expected to be visible in logs because it is also the material sent to HIBP. The suffix and plaintext password must never appear.
 
+Example checker logs:
+
+```text
+2026-04-30 17:00:00 event=validation prefix=5BAA6 pwned=true count=123
+2026-04-30 17:00:00 event=provider_failure fail_closed=true error="Get \"https://api.pwnedpasswords.com/range/5BAA6\": context deadline exceeded"
+```
+
 ## PAM Helper Events
 
 | Event | Meaning | Fields |
@@ -29,6 +36,15 @@
 | `event=pam_helper_failure reason=checker_config` | Checker returned a configuration error. | `reason` |
 | `event=pam_helper_failure reason=checker_provider` | Checker returned a provider error in fail-closed mode. | `reason` |
 | `event=pam_helper_failure reason=checker_exit` | Checker returned an unexpected exit code. | `code` |
+
+The helper may include a bounded `checker_stderr` excerpt for checker configuration, provider, or unexpected-exit failures. The checker must never write plaintext passwords to stderr, and the helper limits this excerpt to keep diagnostics safe and manageable.
+
+Example helper logs:
+
+```text
+event=pam_helper_result result=reject reason=pwned
+event=pam_helper_failure reason=checker_provider checker_stderr="2026-04-30 17:00:00 event=provider_failure fail_closed=true error=\"provider returned HTTP 503\""
+```
 
 ## Rollout Diagnostics
 
@@ -42,3 +58,18 @@ During rollout, operators can count safe event fields:
 - `event=pam_helper_failure reason=checker_provider`
 
 Do not add user identifiers, host account names, plaintext candidates, or full hashes to these event lines.
+
+## Counter Examples
+
+A log pipeline can derive Prometheus-style counters from event fields without parsing secrets:
+
+```text
+pwned_check_validation_total{pwned="true"} 1
+pwned_check_validation_total{pwned="false"} 1
+pwned_check_provider_failure_total{fail_closed="true"} 1
+pwned_check_pam_helper_failure_total{reason="checker_provider"} 1
+```
+
+For Vector-style pipelines, parse the key/value event line and increment counters from `.event`, `.pwned`, `.fail_closed`, and `.reason`. Keep `checker_stderr` as a bounded diagnostic field, not as a counter label.
+
+For Promtail/Loki pipelines, prefer labels with low cardinality such as `event`, `pwned`, `fail_closed`, and `reason`. Do not promote `error`, `checker_stderr`, usernames, host account names, hash prefixes, or candidate-derived values into labels.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -73,6 +73,59 @@ Override locations when needed:
 sudo INSTALL_ROOT=/opt/pwned-check BIN_DIR=/usr/local/bin ./install.sh
 ```
 
+## Ubuntu 24.04 PAM Walkthrough
+
+Use a disposable VM first and keep an existing privileged shell open while editing PAM. The example below uses the packaged install layout on Ubuntu 24.04.
+
+1. Install and verify the package:
+
+   ```bash
+   tar -xzf pwned-check_<version>_linux_amd64.tar.gz
+   cd pwned-check_<version>_linux_amd64
+   sha256sum -c ../pwned-check_<version>_linux_amd64.tar.gz.sha256
+   sudo ./install.sh
+   /usr/local/bin/pwned-check --version
+   /usr/local/bin/pwned-check-pam-helper --version
+   ```
+
+2. Smoke test rejection without PAM:
+
+   ```bash
+   printf 'password\n' | sudo /usr/local/bin/pwned-check-pam-helper --checker /usr/local/bin/pwned-check --timeout 3s
+   echo $?
+   ```
+
+   Expected result: exit code `1` with `event=pam_helper_result result=reject reason=pwned`.
+
+3. Back up the PAM password stack:
+
+   ```bash
+   sudo cp /etc/pam.d/common-password /etc/pam.d/common-password.pwned-check.bak
+   ```
+
+4. Add this line before the `pam_unix.so` password line in `/etc/pam.d/common-password`:
+
+   ```text
+   password requisite pam_exec.so expose_authtok quiet /usr/local/bin/pwned-check-pam-helper --checker /usr/local/bin/pwned-check --timeout 3s
+   ```
+
+5. Test with a dedicated non-production user:
+
+   ```bash
+   sudo passwd <test-user>
+   ```
+
+   Use `password` as the candidate and confirm the change is rejected. Then retry with a strong random value and confirm the normal password-change flow continues.
+
+6. Roll back immediately if password changes behave unexpectedly:
+
+   ```bash
+   sudo cp /etc/pam.d/common-password.pwned-check.bak /etc/pam.d/common-password
+   sudo passwd <test-user>
+   ```
+
+   Keep the privileged shell open until the rollback test reaches the normal password-change flow. If fail-closed provider outages are the issue, switching to fail-open can restore availability, but restoring the PAM backup is the safest emergency recovery.
+
 ## Manual Install Shape
 
 After downloading and verifying a release artifact:
@@ -120,12 +173,28 @@ sudo ln -sfn /usr/local/lib/pwned-check/<previous-helper-binary> /usr/local/lib/
 
 ## PAM Rollback Principle
 
-When PAM integration lands, rollback instructions must include:
+PAM rollback instructions must include:
 
 - how to disable the pwned-check PAM line
 - how to restore the previous PAM file
 - how to test `passwd` after rollback
 - how to avoid locking administrators out of password-change workflows
+
+## PAM Helper Exit Mapping
+
+The PAM helper rejects password changes for more than only known-pwned passwords:
+
+| Checker exit | Meaning | Helper result |
+|---|---|---|
+| `0` | clean, or provider failure when checker fail-open is configured | allow |
+| `1` | pwned password | reject |
+| `2` | checker usage/configuration error | reject |
+| `3` | checker provider/network error in fail-closed mode | reject |
+| timeout | checker exceeded helper timeout | reject |
+
+This means fail-closed provider outages and checker configuration mistakes are deliberately conservative at the PAM boundary.
+
+The helper reads at most 4096 bytes by default. Use `--max-bytes <n>` only if your PAM stack has a documented reason to pass longer tokens; the helper rejects values above 1048576 bytes and should not be treated as an arbitrary stream reader.
 
 ## Configuration
 

--- a/docs/provider-policy.md
+++ b/docs/provider-policy.md
@@ -16,6 +16,8 @@ https://api.pwnedpasswords.com/range/
 
 The endpoint can be overridden with `PWNED_CHECK_HIBP_ENDPOINT` for controlled tests. Production deployments should not override it unless an explicit design decision has approved the alternate provider.
 
+The public HIBP endpoint must use HTTPS. HTTP endpoints are allowed only for controlled non-public test endpoints such as loopback smoke fixtures.
+
 ## Failure Posture
 
 Provider failures are controlled by `PWNED_CHECK_FAIL_CLOSED`.
@@ -43,6 +45,12 @@ Choose this setting before rollout and document the decision for each deployment
 Provider calls use `PWNED_CHECK_TIMEOUT`, in seconds. The default is five seconds.
 
 Password-change integrations should also wrap the checker in their own timeout. The Linux PAM helper does this with its `--timeout` flag so a stalled checker process cannot hang the PAM stack indefinitely.
+
+The checker enforces provider timeout through the request context. The HTTP client does not carry a second independent timeout, which keeps failure timing easier to reason about.
+
+## Request Volume and Rate Limiting
+
+The checker performs one HIBP range request per password candidate and does not retry failed provider requests. The HIBP range API is designed for this k-anonymity lookup pattern, but deployments should avoid invoking the helper on every keystroke or in tight retry loops. PAM placement should call the helper once for a submitted candidate password, and repeated provider failures should be investigated through logs rather than retried aggressively.
 
 ## Test Provider Boundary
 

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -56,7 +56,7 @@ Capture:
 - `go run honnef.co/go/tools/cmd/staticcheck ./...`
 - binary smoke test result
 - Docker smoke matrix result
-- CI `lint`, `test`, `smoke`, and `package-linux` jobs
+- CI `lint`, `staticcheck`, `test`, `smoke`, and `package-linux` jobs
 - any manual Linux/PAM validation once available
 
 ### 4. Build Artifacts
@@ -94,6 +94,8 @@ Do not publish macOS or Windows artifacts until those roadmap tracks include com
 - Create and push the tag.
 - Let GitHub Actions build release artifacts.
 - Verify artifact checksums.
+- Verify release provenance attestation is present for the published checksums.
+- Verify the attestation can be resolved against `SHA256SUMS.txt`.
 - Confirm release notes include:
   - highlights
   - operator impact

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -31,6 +31,7 @@ The password is trusted only inside the OS password-change process, integration 
 ## Password Handling Rules
 
 - Read candidate passwords from stdin only.
+- Bound password reads to 4096 bytes in both the checker and PAM helper.
 - Never accept passwords via command-line arguments.
 - Never log plaintext passwords.
 - Never persist plaintext passwords to disk.
@@ -72,6 +73,14 @@ Provider and integration timeouts are mandatory. Password-change workflows must 
 The PAM integration should enforce its own timeout around the checker process even though the checker also has provider timeouts.
 
 The first Linux PoC uses `pwned-check-pam-helper` for this timeout boundary. The helper reads the PAM-supplied token from stdin and invokes `pwned-check --stdin`; it does not pass the password through argv.
+
+## Process and Environment Exposure
+
+The checker and helper are short-lived processes, so plaintext candidates exist in process memory only for the duration of one validation. Core dump hardening such as `prctl(PR_SET_DUMPABLE, 0)` is not implemented in the current helper; native integration work should revisit this control before handling broader privileged deployments. The helper's `--max-bytes` option has a 1048576-byte ceiling and should not be used to accept arbitrary streams.
+
+The PAM helper inherits its environment when invoking the checker. This is intentional so provider settings such as `PWNED_CHECK_FAIL_CLOSED` and `PWNED_CHECK_TIMEOUT` can be supplied by the integration layer. Environment values must not contain plaintext passwords or full hashes.
+
+Helper argv is safe by design: it contains only helper flags, checker path, and timeout values. Candidate passwords are passed over stdin, never argv, so they should not appear in process listings.
 
 ## Live Provider Dependency
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,7 +85,8 @@ CI should not depend on the live HIBP API. Automated tests use mocked HIBP-compa
 
 The GitHub workflow is split into:
 
-- `lint`: gofmt check, `go vet`, and Staticcheck
+- `lint`: gofmt check and `go vet`
+- `staticcheck`: standalone Staticcheck job, intended to be configured as a required branch-protection check
 - `test`: race-enabled Go tests, bounded parser fuzz smoke, and 85% per-package coverage threshold
 - `smoke`: built-binary smoke, Docker distro smoke, and Docker PAM package smoke against mocked HIBP-compatible endpoints
 - `package-linux`: Linux release package builds for `amd64` and `arm64`
@@ -108,6 +109,12 @@ Release-sensitive checks:
 - Linux package build for `amd64` and `arm64` with SHA256 files
 
 CI intentionally produces only Linux `amd64` and `arm64` distributable artifacts while Linux remains the active integration target. macOS and Windows artifacts should be reintroduced together, with both x64 and arm64 coverage, when those roadmap tracks include their signing requirements.
+
+The repository currently has no branch protection enabled. Once branch protection or rulesets are enabled for `main`, require the `Staticcheck` job alongside the existing test and packaging checks.
+
+## Additional Linters Under Consideration
+
+`golangci-lint` would let the project add `gosec`, `errcheck`, `revive`, and related checks behind one runner. Do not enable it casually: introduce it with a checked-in configuration, review findings for signal, and document any suppressions so the gate does not become noisy coverage theater.
 
 ## Linux Integration Testing
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,8 @@ This guide maps common rollout symptoms to safe diagnostics and likely fixes.
 | `event=pam_helper_failure reason=checker_provider` | Checker hit provider failure in fail-closed mode. | Confirm live HIBP reachability or switch to fail-open if availability is the priority. |
 | `event=pam_helper_failure reason=checker_exit` | Checker returned an unexpected code. | Capture version and command configuration, then investigate as a defect. |
 
+For checker configuration, provider, and unexpected-exit failures, the helper may include a bounded `checker_stderr` excerpt. This field is intended for operational triage and should contain only the checker's safe event output.
+
 ## Common Checks
 
 Confirm binaries:

--- a/internal/pamhelper/helper.go
+++ b/internal/pamhelper/helper.go
@@ -17,6 +17,9 @@ const (
 	ExitAllow  = 0
 	ExitReject = 1
 	ExitUsage  = 2
+
+	defaultMaxTokenBytes      = 4096
+	maxConfigurableTokenBytes = 1 << 20
 )
 
 type Helper struct {
@@ -43,6 +46,7 @@ func (h Helper) Run(args []string) int {
 	flags.SetOutput(stderr)
 	checker := flags.String("checker", "/usr/local/bin/pwned-check", "path to pwned-check binary")
 	timeout := flags.Duration("timeout", 3*time.Second, "maximum checker runtime")
+	maxBytes := flags.Int("max-bytes", defaultMaxTokenBytes, "maximum token size in bytes")
 	versionMode := flags.Bool("version", false, "print version")
 	if err := flags.Parse(args); err != nil {
 		return ExitUsage
@@ -59,8 +63,16 @@ func (h Helper) Run(args []string) int {
 		fmt.Fprintln(stderr, "timeout must be greater than zero")
 		return ExitUsage
 	}
+	if *maxBytes <= 0 {
+		fmt.Fprintln(stderr, "max-bytes must be greater than zero")
+		return ExitUsage
+	}
+	if *maxBytes > maxConfigurableTokenBytes {
+		fmt.Fprintf(stderr, "max-bytes must be less than or equal to %d\n", maxConfigurableTokenBytes)
+		return ExitUsage
+	}
 
-	password, err := readToken(stdin)
+	password, err := readToken(stdin, *maxBytes)
 	if err != nil {
 		fmt.Fprintf(stderr, "event=pam_helper_failure reason=read_token error=%q\n", err)
 		return ExitUsage
@@ -100,21 +112,32 @@ func (h Helper) Run(args []string) int {
 		fmt.Fprintln(stderr, "event=pam_helper_result result=reject reason=pwned")
 		return ExitReject
 	case 2:
-		fmt.Fprintln(stderr, "event=pam_helper_failure reason=checker_config")
+		fmt.Fprintf(stderr, "event=pam_helper_failure reason=checker_config%s\n", checkerStderrField(checkerStderr.String()))
 		return ExitReject
 	case 3:
-		fmt.Fprintln(stderr, "event=pam_helper_failure reason=checker_provider")
+		fmt.Fprintf(stderr, "event=pam_helper_failure reason=checker_provider%s\n", checkerStderrField(checkerStderr.String()))
 		return ExitReject
 	default:
-		fmt.Fprintf(stderr, "event=pam_helper_failure reason=checker_exit code=%d\n", exitErr.ExitCode())
+		fmt.Fprintf(stderr, "event=pam_helper_failure reason=checker_exit code=%d%s\n", exitErr.ExitCode(), checkerStderrField(checkerStderr.String()))
 		return ExitReject
 	}
 }
 
-func readToken(reader io.Reader) (string, error) {
-	const maxTokenBytes = 4096
+func checkerStderrField(value string) string {
+	const maxCheckerStderrBytes = 256
 
-	limited := io.LimitReader(reader, maxTokenBytes+1)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if len(value) > maxCheckerStderrBytes {
+		value = value[:maxCheckerStderrBytes]
+	}
+	return fmt.Sprintf(" checker_stderr=%q", value)
+}
+
+func readToken(reader io.Reader, maxTokenBytes int) (string, error) {
+	limited := io.LimitReader(reader, int64(maxTokenBytes)+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
 		return "", err

--- a/internal/pamhelper/helper_test.go
+++ b/internal/pamhelper/helper_test.go
@@ -51,7 +51,7 @@ func TestHelperRejectsPwnedPassword(t *testing.T) {
 }
 
 func TestHelperRejectsCheckerProviderFailure(t *testing.T) {
-	checker := fakeChecker(t, "exit 3")
+	checker := fakeChecker(t, "echo provider unavailable >&2\nexit 3")
 
 	var stderr bytes.Buffer
 	code := Helper{
@@ -65,10 +65,13 @@ func TestHelperRejectsCheckerProviderFailure(t *testing.T) {
 	if !strings.Contains(stderr.String(), "reason=checker_provider") {
 		t.Fatalf("stderr = %q, want provider failure", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), `checker_stderr="provider unavailable"`) {
+		t.Fatalf("stderr = %q, want checker stderr excerpt", stderr.String())
+	}
 }
 
 func TestHelperRejectsCheckerConfigFailure(t *testing.T) {
-	checker := fakeChecker(t, "exit 2")
+	checker := fakeChecker(t, "echo invalid provider >&2\nexit 2")
 
 	var stderr bytes.Buffer
 	code := Helper{
@@ -82,10 +85,13 @@ func TestHelperRejectsCheckerConfigFailure(t *testing.T) {
 	if !strings.Contains(stderr.String(), "reason=checker_config") {
 		t.Fatalf("stderr = %q, want checker config failure", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), `checker_stderr="invalid provider"`) {
+		t.Fatalf("stderr = %q, want checker stderr excerpt", stderr.String())
+	}
 }
 
 func TestHelperRejectsUnexpectedCheckerExit(t *testing.T) {
-	checker := fakeChecker(t, "exit 9")
+	checker := fakeChecker(t, "echo unexpected failure >&2\nexit 9")
 
 	var stderr bytes.Buffer
 	code := Helper{
@@ -98,6 +104,9 @@ func TestHelperRejectsUnexpectedCheckerExit(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "reason=checker_exit code=9") {
 		t.Fatalf("stderr = %q, want checker exit failure", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `checker_stderr="unexpected failure"`) {
+		t.Fatalf("stderr = %q, want checker stderr excerpt", stderr.String())
 	}
 }
 
@@ -164,6 +173,50 @@ func TestHelperRejectsOversizedToken(t *testing.T) {
 	}
 }
 
+func TestHelperAllowsCustomMaxBytes(t *testing.T) {
+	checker := fakeChecker(t, "exit 0")
+
+	var stderr bytes.Buffer
+	code := Helper{
+		Stdin:  strings.NewReader("abcde\n"),
+		Stderr: &stderr,
+	}.Run([]string{"--checker", checker, "--timeout", "1s", "--max-bytes", "8"})
+
+	if code != ExitAllow {
+		t.Fatalf("code = %d, want %d; stderr=%s", code, ExitAllow, stderr.String())
+	}
+}
+
+func TestHelperRejectsInvalidMaxBytes(t *testing.T) {
+	var stderr bytes.Buffer
+	code := Helper{
+		Stdin:  strings.NewReader("candidate\n"),
+		Stderr: &stderr,
+	}.Run([]string{"--checker", "/bin/true", "--timeout", "1s", "--max-bytes", "0"})
+
+	if code != ExitUsage {
+		t.Fatalf("code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "max-bytes must be greater than zero") {
+		t.Fatalf("stderr = %q, want max-bytes validation", stderr.String())
+	}
+}
+
+func TestHelperRejectsExcessiveMaxBytes(t *testing.T) {
+	var stderr bytes.Buffer
+	code := Helper{
+		Stdin:  strings.NewReader("candidate\n"),
+		Stderr: &stderr,
+	}.Run([]string{"--checker", "/bin/true", "--timeout", "1s", "--max-bytes", "1048577"})
+
+	if code != ExitUsage {
+		t.Fatalf("code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "max-bytes must be less than or equal to 1048576") {
+		t.Fatalf("stderr = %q, want max-bytes upper-bound validation", stderr.String())
+	}
+}
+
 func TestHelperRejectsMissingChecker(t *testing.T) {
 	var stderr bytes.Buffer
 	code := Helper{
@@ -211,7 +264,7 @@ func TestHelperVersion(t *testing.T) {
 }
 
 func TestReadTokenTrimsLineEndings(t *testing.T) {
-	token, err := readToken(strings.NewReader("candidate\r\n"))
+	token, err := readToken(strings.NewReader("candidate\r\n"), 4096)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,9 +274,19 @@ func TestReadTokenTrimsLineEndings(t *testing.T) {
 }
 
 func TestReadTokenPropagatesReadError(t *testing.T) {
-	_, err := readToken(errReader{})
+	_, err := readToken(errReader{}, 4096)
 	if err == nil {
 		t.Fatal("readToken succeeded, want error")
+	}
+}
+
+func TestCheckerStderrFieldIsBounded(t *testing.T) {
+	field := checkerStderrField(strings.Repeat("a", 300))
+	if !strings.HasPrefix(field, ` checker_stderr="`) {
+		t.Fatalf("field = %q, want checker_stderr field", field)
+	}
+	if strings.Count(field, "a") != 256 {
+		t.Fatalf("field has %d a characters, want 256", strings.Count(field, "a"))
 	}
 }
 

--- a/internal/pwned/cli.go
+++ b/internal/pwned/cli.go
@@ -95,9 +95,15 @@ func (c CLI) Run(args []string) int {
 }
 
 func readPassword(reader io.Reader) (string, error) {
-	line, err := bufio.NewReader(reader).ReadString('\n')
+	const maxPasswordBytes = 4096
+
+	limited := io.LimitReader(reader, maxPasswordBytes+1)
+	line, err := bufio.NewReader(limited).ReadString('\n')
 	if err != nil && err != io.EOF {
 		return "", err
+	}
+	if len(line) > maxPasswordBytes {
+		return "", fmt.Errorf("password exceeds %d bytes", maxPasswordBytes)
 	}
 	return strings.TrimRight(line, "\r\n"), nil
 }

--- a/internal/pwned/cli_test.go
+++ b/internal/pwned/cli_test.go
@@ -123,6 +123,31 @@ func TestCLIVersion(t *testing.T) {
 	}
 }
 
+func TestCLIRejectsOversizedPassword(t *testing.T) {
+	var stderr bytes.Buffer
+	code := CLI{
+		Stdin:  strings.NewReader(strings.Repeat("a", 4097)),
+		Stderr: &stderr,
+	}.Run([]string{"--stdin"})
+
+	if code != ExitConfig {
+		t.Fatalf("code = %d, want %d", code, ExitConfig)
+	}
+	if !strings.Contains(stderr.String(), "password exceeds 4096 bytes") {
+		t.Fatalf("stderr = %q, want oversized password error", stderr.String())
+	}
+}
+
+func TestReadPasswordTrimsLineEndings(t *testing.T) {
+	password, err := readPassword(strings.NewReader("candidate\r\nignored"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if password != "candidate" {
+		t.Fatalf("password = %q, want candidate", password)
+	}
+}
+
 func TestCLIFailClosedProviderTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)

--- a/internal/pwned/config.go
+++ b/internal/pwned/config.go
@@ -10,12 +10,11 @@ import (
 )
 
 type Config struct {
-	Provider       string
-	FailClosed     bool
-	Timeout        time.Duration
-	LocalURL       string
-	HIBPEndpoint   string
-	InteractiveTTY bool
+	Provider     string
+	FailClosed   bool
+	Timeout      time.Duration
+	LocalURL     string
+	HIBPEndpoint string
 }
 
 func LoadConfig() (Config, error) {
@@ -54,27 +53,38 @@ func LoadConfig() (Config, error) {
 		return Config{}, fmt.Errorf("missing PWNED_CHECK_LOCAL_URL for provider=local")
 	}
 	if cfg.Provider == "local" {
-		if err := validateHTTPURL("PWNED_CHECK_LOCAL_URL", cfg.LocalURL); err != nil {
+		if _, err := validateHTTPURL("PWNED_CHECK_LOCAL_URL", cfg.LocalURL); err != nil {
 			return Config{}, err
 		}
 	}
-	if err := validateHTTPURL("PWNED_CHECK_HIBP_ENDPOINT", cfg.HIBPEndpoint); err != nil {
+	if err := validateHIBPEndpoint(cfg.HIBPEndpoint); err != nil {
 		return Config{}, err
 	}
 
 	return cfg, nil
 }
 
-func validateHTTPURL(name, value string) error {
+func validateHIBPEndpoint(value string) error {
+	parsed, err := validateHTTPURL("PWNED_CHECK_HIBP_ENDPOINT", value)
+	if err != nil {
+		return err
+	}
+	if strings.EqualFold(parsed.Hostname(), "api.pwnedpasswords.com") && parsed.Scheme != "https" {
+		return fmt.Errorf("PWNED_CHECK_HIBP_ENDPOINT must use https for api.pwnedpasswords.com")
+	}
+	return nil
+}
+
+func validateHTTPURL(name, value string) (*url.URL, error) {
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return fmt.Errorf("invalid %s", name)
+		return nil, fmt.Errorf("invalid %s", name)
 	}
 	switch parsed.Scheme {
 	case "http", "https":
-		return nil
+		return parsed, nil
 	default:
-		return fmt.Errorf("invalid %s scheme %q", name, parsed.Scheme)
+		return nil, fmt.Errorf("invalid %s scheme %q", name, parsed.Scheme)
 	}
 }
 

--- a/internal/pwned/config_test.go
+++ b/internal/pwned/config_test.go
@@ -77,3 +77,21 @@ func TestLoadConfigRejectsInvalidLocalURL(t *testing.T) {
 		t.Fatal("LoadConfig succeeded, want invalid local URL error")
 	}
 }
+
+func TestLoadConfigRejectsHTTPPublicHIBPEndpoint(t *testing.T) {
+	t.Setenv("PWNED_CHECK_PROVIDER", "hibp")
+	t.Setenv("PWNED_CHECK_HIBP_ENDPOINT", "http://api.pwnedpasswords.com/range/")
+
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("LoadConfig succeeded, want public HIBP https error")
+	}
+}
+
+func TestLoadConfigAllowsHTTPCustomHIBPEndpointForTests(t *testing.T) {
+	t.Setenv("PWNED_CHECK_PROVIDER", "hibp")
+	t.Setenv("PWNED_CHECK_HIBP_ENDPOINT", "http://127.0.0.1:8000/range/")
+
+	if _, err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig failed for controlled test endpoint: %v", err)
+	}
+}

--- a/internal/pwned/provider.go
+++ b/internal/pwned/provider.go
@@ -26,7 +26,7 @@ func NewHIBPProvider(endpoint string, timeout time.Duration) RangeProvider {
 	headers.Set("Add-Padding", "true")
 	return RangeProvider{
 		BaseURL: strings.TrimRight(endpoint, "/") + "/",
-		Client:  &http.Client{Timeout: timeout},
+		Client:  &http.Client{},
 		Header:  headers,
 		Timeout: timeout,
 	}
@@ -35,7 +35,7 @@ func NewHIBPProvider(endpoint string, timeout time.Duration) RangeProvider {
 func NewLocalProvider(baseURL string, timeout time.Duration) RangeProvider {
 	return RangeProvider{
 		BaseURL: strings.TrimRight(baseURL, "/") + "/range/",
-		Client:  &http.Client{Timeout: timeout},
+		Client:  &http.Client{},
 		Header:  http.Header{},
 		Timeout: timeout,
 	}
@@ -59,7 +59,11 @@ func (p RangeProvider) Lookup(prefix, suffix string) (int, error) {
 		}
 	}
 
-	resp, err := p.Client.Do(req)
+	client := p.Client
+	if client == nil {
+		client = &http.Client{}
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary
- split Staticcheck into a standalone CI check and require it before smoke/package jobs
- add release provenance attestation over published SHA256 checksums
- add PAM helper max-bytes configuration with bounded stderr diagnostics
- document operational logging counters, HIBP request posture, Ubuntu PAM rollout, rollback, and release validation

## Validation
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck ./...
- make coverage
- make fuzz-smoke
- git diff --check
- scripts/project-board-audit.sh
- pre-push local validation gate passed during branch push